### PR TITLE
Fixed subcollection behaviour when contacting the firestore API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ dist/
 .coverage
 coverage.xml
 
-
+venv/
+wvenv/
 

--- a/matchbox/models/fields.py
+++ b/matchbox/models/fields.py
@@ -207,7 +207,7 @@ class ReferenceField(Field):
                 )
             )
         return firestore.DocumentReference(
-            value.collection_name(), value.id, client=db.conn
+            value.full_collection_name(), value.id, client=db.conn
         )
 
     def python_value(self, value):

--- a/matchbox/models/models.py
+++ b/matchbox/models/models.py
@@ -95,7 +95,7 @@ class BaseModel(type):
         pk = fields.IDField()
         pk.contribute_to_class(cls, 'id')
 
-        setattr(cls, 'path', (cls._meta.collection_name, ))
+        cls.path = (cls._meta.collection_name, )
 
         return cls
 
@@ -114,6 +114,10 @@ class Model(metaclass=BaseModel):
     @classmethod
     def collection_name(cls):
         return cls._meta.collection_name
+
+    @classmethod
+    def full_collection_name(cls):
+        return "/".join(cls.path)
 
     @classmethod
     def get_field(cls, name):

--- a/matchbox/queries/queries.py
+++ b/matchbox/queries/queries.py
@@ -35,7 +35,7 @@ class QueryBase:
         self.model = model
 
     def get_ref(self):
-        return db.conn.collection("/".join(self.model.path))
+        return db.conn.collection(self.model.full_collection_name())
 
 
 class FilterQuery(QueryBase):
@@ -69,7 +69,7 @@ class FilterQuery(QueryBase):
 
             if isinstance(field, fields.ReferenceField):
                 vl = utils.get_reference_fields(
-                    field.ref_model.collection_name(),
+                    field.ref_model.full_collection_name(),
                     vl.id if hasattr(vl, 'id') else vl,
                 )
 

--- a/matchbox/tests/test_fields.py
+++ b/matchbox/tests/test_fields.py
@@ -297,7 +297,7 @@ class TestReferenceField(unittest.TestCase):
         self.RefModel = type(
             'RefModel',
             (self.Model, ),
-            {'id': 'AEX1213', 'collection_name': lambda x: None}
+            {'id': 'AEX1213', 'collection_name': lambda x: None, 'full_collection_name': lambda x: None}
         )
 
     def test_lookup_value_none_returns_none(self):

--- a/matchbox/tests/test_model.py
+++ b/matchbox/tests/test_model.py
@@ -76,6 +76,26 @@ class TestModel(unittest.TestCase):
 
         self.assertEqual(TestModelClass.collection_name(), 'ownName')
 
+    def test_full_collection_name(self):
+        class TestModelClassParent(models.Model):
+            name = models.TextField()
+            age = models.IntegerField()
+
+        class TestModelClass(models.Model):
+            name = models.TextField()
+            age = models.IntegerField()
+
+            class Meta:
+                collection_name = 'tmc'
+
+        tmcp = TestModelClassParent()
+        tmcp.id = 'AEX123123'
+
+        TestModelClass.set_base_path(tmcp)
+
+        self.assertEqual(TestModelClassParent.full_collection_name(), 'test_model_class_parent')
+        self.assertEqual(TestModelClass.full_collection_name(), 'test_model_class_parent/AEX123123/tmc')
+
     def test_path(self):
         class TestModelClassParent(models.Model):
             name = models.TextField()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='matchbox-orm',
-    version='0.2.4',
+    version='0.2.5',
     description='matchbox is orm package for google Cloud Firestore',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I attempted to use the new subcollection functionality and ran into issues when querying based on a ReferenceField and saving a model that has a ReferenceField.

My solution was to add a method in Model called 'full_collection_name' which returns the path in a '/' separated string.